### PR TITLE
Add United States Minor Outlying Islands

### DIFF
--- a/country-codes.csv
+++ b/country-codes.csv
@@ -214,6 +214,7 @@ Europe,Eastern Europe,Ukraine,Kiev,UP,UA,UKR,804,UA
 Asia,South West Asia,United Arab Emirates,Abu Dhabi,TC,AE,ARE,784,AE
 Europe,Western Europe,United Kingdom,London,UK,GB,GBR,826,UK
 Americas,North America,United States,Washington DC,US,US,USA,840,US
+Americas,North America,United States Minor Outlying Islands,Washington DC,,UM,UMI,581,US
 Americas,South America,Uruguay,Montevideo,UY,UY,URY,858,UY
 Asia,Central Asia,Uzbekistan,Tashkent (Toshkent),UZ,UZ,UZB,860,UZ
 Oceania,Pacific,Vanuatu,Port-Vila,NH,VU,VUT,548,VU


### PR DESCRIPTION
Omitted fips, because the each of the islands have their own code. Omitted fips, because the each of the islands have their own code. 