### PR TITLE
Kosovo / XK

### DIFF
--- a/index.js
+++ b/index.js
@@ -2785,7 +2785,18 @@ var countries = [
     iso3: 'BES',
     isoNo: '535',
     internet: 'BQ'
-  }
+  },
+  {
+    continent: 'Europe',
+    region: 'South East Europe',
+    country: 'Republic of Kosovo',
+    capital: 'Pristina',
+    fips: 'XK',
+    iso2: 'XK',
+    iso3: 'UNK',
+    isoNo: null,
+    internet: 'XK'
+  },
 ]
 
 module.exports.countries = countries


### PR DESCRIPTION
This PR adds Republic of Kosovo to the list of recognised countries

Note, XK is not an officially recognised ISO code, but a [self-assigned one](https://en.wikipedia.org/wiki/ISO_3166-2:RS#Note), which is also why there is no `isoNo`. Likewise, I'm not sure if UNK is the right thing to use in place of the alpha-3 code, as it's not an official alpha-3 code, but from an older standard and currently [agreed to not be used](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3#Codes_currently_agreed_not_to_use). (So probably not, but there isn't anything else on offer.) The internet TLD is only still a proposal.

PS. I wasn't sure how the list of countries was sorted. I couldn't see any obvious pattern, so I just tacked it on the end. Please advise if there is a sort order, and I shall amend.