### PR TITLE
Fix Macedonia -> North Macedonia and Swaziland -> Eswatini

### DIFF
--- a/index.js
+++ b/index.js
@@ -1337,7 +1337,7 @@ var countries = [
   {
     continent: 'Europe',
     region: 'South East Europe',
-    country: 'Macedonia',
+    country: 'North Macedonia',
     capital: 'Skopje',
     fips: 'MK',
     iso2: 'MK',
@@ -2162,8 +2162,8 @@ var countries = [
   {
     continent: 'Africa',
     region: 'Southern Africa',
-    country: 'Swaziland',
-    capital: 'Mbabane��',
+    country: 'Eswatini',
+    capital: 'Mbabane',
     fips: 'WZ',
     iso2: 'SZ',
     iso3: 'SWZ',


### PR DESCRIPTION
Fairly straightforward, check Wikipedia for the political reasons. As far as I know none of the codes were changed (did a cursory check, but no in depth check).