### PR TITLE
Fix more correct transliteration of capital of Ukraine

### DIFF
--- a/index.js
+++ b/index.js
@@ -2361,7 +2361,7 @@ var countries = [
     continent: 'Europe',
     region: 'Eastern Europe',
     country: 'Ukraine',
-    capital: 'Kiev',
+    capital: 'Kyiv',
     fips: 'UP',
     iso2: 'UA',
     iso3: 'UKR',


### PR DESCRIPTION
Fix more correct transliteration of capital of Ukraine (derived from the Ukrainian language name Київ) instead of Kiev (derived from the Russian language name Киев)

https://en.wikipedia.org/wiki/KyivNotKiev
https://en.wikipedia.org/wiki/Kyiv